### PR TITLE
Adjust account creation to latest noobaa-core changes and rename SSHConnection

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -49,7 +49,7 @@ def main(argv=None):
     arguments.extend(
         [
             "-p",
-            "framework.connection",
+            "framework.ssh_connection_manager",
             "-p",
             "framework.customizations.custom_cmd_line_arguments",
         ]

--- a/framework/ssh_connection_manager.py
+++ b/framework/ssh_connection_manager.py
@@ -11,7 +11,7 @@ from paramiko.auth_handler import AuthenticationException, SSHException
 log = logging.getLogger(__name__)
 
 
-class SSHConnection:
+class SSHConnectionManager:
     """
     A class that connects to remote host
     """
@@ -20,7 +20,7 @@ class SSHConnection:
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
-            cls._instance = super(SSHConnection, cls).__new__(cls)
+            cls._instance = super(SSHConnectionManager, cls).__new__(cls)
         return cls._instance
 
     def __init__(self):
@@ -85,4 +85,4 @@ class SSHConnection:
 
 def pytest_sessionfinish(session, exitstatus):
     # Close the SSH connection at the end of the pytest session
-    SSHConnection.close_connection()
+    SSHConnectionManager.close_connection()

--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -91,6 +91,7 @@ class NSFSAccount(Account):
         account_data = {
             "account_name": account_name,
             "account_email": account_email,
+            # creation_date is required due to https://bugzilla.redhat.com/show_bug.cgi?id=2260325
             "creation_date": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "access_key": access_key,
             "secret_key": secret_key,

--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from common_ci_utils.templating import Templating
 
 from framework import config
-from framework.connection import SSHConnection
+from framework.ssh_connection_manager import SSHConnectionManager
 from noobaa_sa.defaults import MANAGE_NSFS
 from noobaa_sa.exceptions import (
     AccountCreationFailed,
@@ -38,7 +38,7 @@ class Account(ABC):
         self.account_json = account_json
         self.manage_nsfs = MANAGE_NSFS
         self.config_root = config.ENV_DATA["config_root"]
-        self.conn = SSHConnection().connection
+        self.conn = SSHConnectionManager().connection
 
     @abstractmethod
     def create(self):

--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -5,6 +5,7 @@ Module which contain account operations like create, delete, list and update
 import logging
 import os
 import tempfile
+from datetime import datetime
 from abc import ABC, abstractmethod
 
 from common_ci_utils.templating import Templating
@@ -12,6 +13,7 @@ from common_ci_utils.templating import Templating
 from framework import config
 from framework.ssh_connection_manager import SSHConnectionManager
 from noobaa_sa.defaults import MANAGE_NSFS
+from noobaa_sa import constants
 from noobaa_sa.exceptions import (
     AccountCreationFailed,
     AccountDeletionFailed,
@@ -58,7 +60,14 @@ class NSFSAccount(Account):
     Account operations for NSFS Deployment type
     """
 
-    def create(self, account_name, access_key, secret_key, config_root=None):
+    def create(
+        self,
+        account_name,
+        access_key,
+        secret_key,
+        config_root=None,
+        fs_backend=constants.DEFAULT_FS_BACKEND,
+    ):
         """
         Account creation using file
 
@@ -82,9 +91,11 @@ class NSFSAccount(Account):
         account_data = {
             "account_name": account_name,
             "account_email": account_email,
+            "creation_date": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "access_key": access_key,
             "secret_key": secret_key,
             "bucket_path": bucket_path,
+            "fs_backend": fs_backend,
         }
         account_data_full = templating.render_template(account_template, account_data)
         log.info(f"account content: {account_data_full}")
@@ -96,6 +107,8 @@ class NSFSAccount(Account):
             account_file.write(account_data_full)
 
         # upload to noobaa-sa host
+        self.conn.exec_cmd(f"sudo mkdir -p {os.path.dirname(account_file.name)}")
+        self.conn.exec_cmd(f"sudo chmod a+w {os.path.dirname(account_file.name)}")
         self.conn.upload_file(account_file.name, account_file.name)
 
         if config_root is None:
@@ -106,7 +119,7 @@ class NSFSAccount(Account):
         retcode, stdout, stderr = self.conn.exec_cmd(cmd)
         if retcode != 0:
             raise AccountCreationFailed(
-                f"Creation of account failed with error {stderr}"
+                f"Creation of account failed with error {stdout}"
             )
         log.info("Account created successfully")
 

--- a/noobaa_sa/bucket.py
+++ b/noobaa_sa/bucket.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from framework import config
-from framework.connection import SSHConnection
+from framework.ssh_connection_manager import SSHConnectionManager
 from noobaa_sa.defaults import MANAGE_NSFS
 import noobaa_sa.exceptions as e
 
@@ -26,7 +26,7 @@ class BucketManager:
         self.config_root = config.ENV_DATA["config_root"]
         self.base_cmd = f"sudo /usr/local/noobaa-core/bin/node {self.manage_nsfs}"
         self.unwanted_log = "2>/dev/null"
-        self.conn = SSHConnection().connection
+        self.conn = SSHConnectionManager().connection
 
     def create(self, account_name, bucket_name, config_root=None):
         """

--- a/noobaa_sa/constants.py
+++ b/noobaa_sa/constants.py
@@ -5,3 +5,4 @@ This module contains constant value which will be used across project
 DEPLOYMENT_TYPES = ["nsfs", "db"]
 NSFS_DEPLOYMENT = "nsfs"
 DB_DEPLOYMENT = "db"
+DEFAULT_FS_BACKEND = "GPFS"

--- a/templates/account.json
+++ b/templates/account.json
@@ -1,8 +1,7 @@
 {
     "name": "{{account_name}}",
     "email": "{{account_email}}",
-    "has_login": "false",
-    "has_s3_access": "true",
+    "creation_date": "{{creation_date}}",
     "allow_bucket_creation": "true",
     "access_keys": [
         {
@@ -14,6 +13,6 @@
         "uid": 0,
         "gid": 0,
         "new_buckets_path": "{{bucket_path}}",
-        "nsfs_only": "true"
+        "fs_backend": "{{fs_backend}}"
     }
 }

--- a/tests/test_account_operations.py
+++ b/tests/test_account_operations.py
@@ -4,11 +4,13 @@ import tempfile
 
 from common_ci_utils.templating import Templating
 from framework import config
+from framework.ssh_connection_manager import SSHConnectionManager
 
 log = logging.getLogger(__name__)
 
 
 def test_account_operations(account_manager, unique_resource_name, random_hex):
+    conn = SSHConnectionManager().connection
     # account operations
     account_name = unique_resource_name(prefix="account")
     access_key = random_hex()

--- a/tests/test_account_operations.py
+++ b/tests/test_account_operations.py
@@ -1,16 +1,11 @@
 import logging
-import os
-import tempfile
 
-from common_ci_utils.templating import Templating
 from framework import config
-from framework.ssh_connection_manager import SSHConnectionManager
 
 log = logging.getLogger(__name__)
 
 
 def test_account_operations(account_manager, unique_resource_name, random_hex):
-    conn = SSHConnectionManager().connection
     # account operations
     account_name = unique_resource_name(prefix="account")
     access_key = random_hex()

--- a/tests/test_bucket_operations.py
+++ b/tests/test_bucket_operations.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from framework.connection import SSHConnection
+from framework.ssh_connection_manager import SSHConnectionManager
 
 log = logging.getLogger(__name__)
 
@@ -10,7 +10,7 @@ def test_bucket_operations(
     account_manager, bucket_manager, unique_resource_name, random_hex
 ):
     # Create SSH connection
-    conn = SSHConnection().connection
+    conn = SSHConnectionManager().connection
     # Bucket operations
     account_name = unique_resource_name(prefix="account")
     access_key = random_hex()


### PR DESCRIPTION
1. Adjust account creation to latest noobaa-core changes

2. Rename SSHConnection to SSHConnectionManager, and the name of its containing file from connection.py to ssh_connection_manager. This is both for clarification and to support extending the base connection class in a follow up PR.

3. Minor semantics: Black enforcement and removal of the imports of unused modules 

Pass logs: https://privatebin.corp.redhat.com/?f084d3049cb5189b#E8FaiPBy9n1Yk7ipLXyS44fsn6eCyHN88MsWVeHQcKqN