### PR TITLE
Add necessary config_root setup to setup_nsfs_server_tls_cert

### DIFF
--- a/noobaa_sa/constants.py
+++ b/noobaa_sa/constants.py
@@ -9,4 +9,4 @@ NSFS_SERVICE_NAME = "noobaa_nsfs"
 DEFAULT_FS_BACKEND = "GPFS"
 UNWANTED_LOG = "2>/dev/null"
 DEFAULT_NSFS_PORT = 6443
-DEFAULT_CONFIG_ROOT_PATH = "/etc/noobaa.conf.d/config_root"
+DEFAULT_CONFIG_ROOT_PATH = "/etc/noobaa.conf.d"

--- a/noobaa_sa/constants.py
+++ b/noobaa_sa/constants.py
@@ -9,3 +9,4 @@ NSFS_SERVICE_NAME = "noobaa_nsfs"
 DEFAULT_FS_BACKEND = "GPFS"
 UNWANTED_LOG = "2>/dev/null"
 DEFAULT_NSFS_PORT = 6443
+DEFAULT_CONFIG_ROOT_PATH = "/etc/noobaa.conf.d/config_root"

--- a/utility/nsfs_server_utils.py
+++ b/utility/nsfs_server_utils.py
@@ -155,24 +155,3 @@ def set_nsfs_service_certs_dir(creds_dir, config_root=config.ENV_DATA["config_ro
     system_json = json.loads(stdout)
     system_json["nsfs_ssl_key_dir"] = creds_dir
     conn.exec_cmd(f"echo '{json.dumps(system_json)}' > {config_root}/system.json")
-
-
-def redirect_nsfs_to_use_config_dir(config_root):
-    """
-    Prepare a dir to be used as the config root for the NSFS service
-    in the CI
-
-    Args:
-        config_root (str): The full path to the config dir on the remote machine
-
-    """
-    conn = SSHConnectionManager().connection
-
-    # The presence of the system.json file in the dir
-    # indicates that the NSFS service can it as the config root
-    _, stdout, _ = conn.exec_cmd(f"sudo ls {config_root}")
-    if "system.json" not in stdout:
-        conn.exec_cmd(
-            f"echo '{config_root}' | sudo tee /etc/noobaa.conf.d/config_dir_redirect"
-        )
-        restart_nsfs_service()

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -39,9 +39,10 @@ def get_current_test_name():
     return os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0]
 
 
-def get_config_root_full_path():
+def get_env_config_root_full_path():
     """
-    Get the full path of the configuration root directory on the remote machine
+    Get the full path of directory that's specified as the config_root
+    in under ENV_DATA in the CI's configuration
 
     Returns:
         str: The full path of the configuration root directory on the remote machine


### PR DESCRIPTION
1. Automates [this step](https://github.com/noobaa/noobaa-core/blob/c38086e36c8d45b93d69382e7110b403472107df/docs/non_containerized_NSFS.md?plain=1#L83-L90) of the setup that we've had to do manually on new instances until now: 

```
echo "/path/to/config/dir" > /etc/noobaa.conf.d/config_dir_redirect
```

2. Loosen the permission on the config_root dir during setup - this has been another manual step that was necessary for certain file operations like the download of the tls cert.