### PR TITLE
Fix the check for the existence of the `tls.crt` file on the remote machine in `check_nsfs_tls_cert_setup`

### DIFF
--- a/utility/nsfs_server_utils.py
+++ b/utility/nsfs_server_utils.py
@@ -217,7 +217,7 @@ def check_nsfs_tls_cert_setup(config_root):
         return False
 
     # Check if a TLS certificate file exists on the remote machine under the config root
-    retcode, _, _ = conn.exec_cmd(f"[ -d '{config_root}/certificates/tls.crt/' ]")
+    retcode, _, _ = conn.exec_cmd(f"sudo [ -e '{config_root}/certificates/tls.crt' ]")
     if retcode != 0:
         log.info(
             f"NSFS server TLS certificate was not found under {config_root}/certificates"


### PR DESCRIPTION
The previous check would always fail due to multiple mistakes in the command:

1. not using sudo 
2. `-d` ("is directory) instead of `-e` ("does this file/directory exist")
3. The use of '/' at the end of the string that is supposed to be the path of a file and not a directory

This would cause the check to always fail and rerun the TLS certification setup, which is both a waste of time and a potential cause of errors - rerunning the TLS certification setup invalidates the previous certificate, which in turn could cause unexpected SSL errors .

Here are the passing logs of the existing tests: https://privatebin.corp.redhat.com/?44159f8535cd5486#CZLJ9aHpLQ8tS8iBh6h5SZmbvDCCsgHEc8hptprTCBJk