### PR TITLE
Adjust setup related fixtures to the latest changes to noobaa-core

### DIFF
--- a/utility/nsfs_server_utils.py
+++ b/utility/nsfs_server_utils.py
@@ -241,9 +241,9 @@ def check_nsfs_tls_cert_setup(config_root):
     # Check if the local and remote certificates match
     comp_result = False
     with tempfile.TemporaryDirectory() as tmp_dir:
-        local_crt_file = f"{tmp_dir}/tls.crt"
-        download_file_via_ssh(remote_crt_path, local_crt_file.name)
-        comp_result = compare_md5sums(local_crt_file, S3Client.static_tls_crt_path)
+        local_crt_path = f"{tmp_dir}/tls.crt"
+        download_file_via_ssh(remote_crt_path, local_crt_path)
+        comp_result = compare_md5sums(local_crt_path, S3Client.static_tls_crt_path)
 
     return comp_result
 

--- a/utility/nsfs_server_utils.py
+++ b/utility/nsfs_server_utils.py
@@ -144,10 +144,12 @@ def get_system_json(config_root=config.ENV_DATA["config_root"]):
         dict: The content of the system.json file
     """
     conn = SSHConnectionManager().connection
-    retcode, stdout, _ = conn.exec_cmd(f"sudo cat {config_root}/system.json")
+    retcode, stdout, stderr = conn.exec_cmd(f"sudo cat {config_root}/system.json")
     if retcode != 0:
         raise MissingFileOrDirectory(
-            f"system.json file not found in {config_root}: {stdout}"
+            f"system.json file not found in {config_root}\n:"
+            f"stdout: {stdout}\n"
+            f"stderr: {stderr}\n"
         )
     return json.loads(stdout)
 

--- a/utility/retry.py
+++ b/utility/retry.py
@@ -1,0 +1,72 @@
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def retry_until_timeout(func, timeout=300, interval=5, *args, **kwargs):
+    """
+    Retry the function until it returns True or the timeout is reached.
+
+    Args:
+        func (func): The function to retry.
+        timeout (int): The maximum time to retry the function.
+        interval (int): The time between retries.
+
+    Returns:
+        Any: The return value of the function.
+
+    Raises:
+        Any exception: raise the exception the function last raised.
+
+    """
+    start_time = time.time()
+    elapsed_time = time.time() - start_time
+    while True:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.warning(f"{func.__name__} failed with exception: {e}")
+            if elapsed_time > timeout:
+                logger.error(f"{func.__name__} failed after {timeout} seconds")
+                raise e
+            else:
+                elapsed_time = time.time() - start_time
+                time_left = timeout - elapsed_time
+                logger.info(
+                    f"Retrying {func.__name__} in {interval} seconds: {time_left} seconds until timeout"
+                )
+                time.sleep(interval)
+
+
+def retry_number_of_times(func, retries=3, interval=5, *args, **kwargs):
+    """
+    Retry the function a number of times.
+
+    Args:
+        func (func): The function to retry.
+        retries (int): The number of times to retry the function.
+        interval (int): The time between retries.
+
+    Returns:
+        Any: The return value of the function.
+
+    Raises:
+        Any exception: raise the exception the function last raised.
+
+    """
+    import time
+
+    for attempt_num in range(retries):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.warning(f"{func.__name__} failed with exception: {e}")
+            if attempt_num == retries - 1:
+                logger.error(f"{func.__name__} failed after {retries} attempts")
+                raise e
+            else:
+                logger.info(
+                    f"Retrying {func.__name__} in {interval} seconds: {retries - attempt_num - 1} attempts left"
+                )
+                time.sleep(interval)

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -117,7 +117,7 @@ def split_file_data_for_multipart_upload(file_name, part_size=None):
     return all_chunks
 
 
-def generate_random_key(length=20):
+def generate_random_key(length=20, alphanumeric=True):
     """
     Generates a random string with the given length
 
@@ -132,11 +132,14 @@ def generate_random_key(length=20):
     mandatory_chars.append(random.choice(string.ascii_uppercase))
     mandatory_chars.append(random.choice(string.digits))
 
-    # Generate the rest of the key and make sure it doesn't contain any invalid characters
-    invalid_chars = ["\\", "/", " ", '"', "'"]
-    valid_special_characters = "".join(
-        ch for ch in string.punctuation if ch not in invalid_chars
-    )
+    valid_special_characters = ""
+    if not alphanumeric:
+        # Generate the rest of the key and make sure it doesn't contain any invalid characters
+        invalid_chars = ["\\", "/", " ", '"', "'"]
+        valid_special_characters = "".join(
+            ch for ch in string.punctuation if ch not in invalid_chars
+        )
+
     valid_characters = string.ascii_letters + string.digits + valid_special_characters
     key_chars = random.choices(valid_characters, k=length - len(mandatory_chars))
 


### PR DESCRIPTION
Fixes:

- #27:
Since we can bypass these restrictions when using sudo via ssh, but not via sftp - the workaround is to copy the file via `sudo cp` to an unrestricted directory and then use sftp to download it form there.

- #31:
By modifying `generate_random_key` to create alphanumeric keys by default.

- #30:
Fixed the race condition by using a new `retry` util func when we attempt to read the file from a newly set config directory
