### PR TITLE
Add the remaining bucket policies tests

### DIFF
--- a/framework/bucket_policies/access_validation_strategies/access_validation_strategy_interface.py
+++ b/framework/bucket_policies/access_validation_strategies/access_validation_strategy_interface.py
@@ -8,6 +8,8 @@ class AccessValidationStrategy(ABC):
 
     """
 
+    TEST_OBJ_PREFIX = "test-obj-"
+
     def __init__(self, admin_client, bucket):
         super().__init__()
         self.admin_client = admin_client

--- a/framework/bucket_policies/access_validation_strategies/copy_object_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/copy_object_validation_strategy.py
@@ -14,9 +14,9 @@ class CopyObjectValidationStrategy(AccessValidationStrategy):
         return 200
 
     def setup(self, **setup_kwargs):
-        self.test_obj_key = generate_unique_resource_name(prefix="test-obj-")
+        self.test_obj_key = generate_unique_resource_name(prefix=self.TEST_OBJ_PREFIX)
         self.admin_client.put_object(self.bucket, self.test_obj_key, "test_data")
 
     def do_operation(self, s3_client, bucket):
-        new_obj_key = generate_unique_resource_name(prefix="test-obj-")
+        new_obj_key = generate_unique_resource_name(prefix=self.TEST_OBJ_PREFIX)
         return s3_client.copy_object(bucket, self.test_obj_key, bucket, new_obj_key)

--- a/framework/bucket_policies/access_validation_strategies/delete_object_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/delete_object_validation_strategy.py
@@ -17,7 +17,9 @@ class DeleteObjectValidationStrategy(AccessValidationStrategy):
         if "obj_key" in setup_kwargs:
             self.test_obj_key = setup_kwargs["obj_key"]
         else:
-            self.test_obj_key = generate_unique_resource_name(prefix="test-obj-")
+            self.test_obj_key = generate_unique_resource_name(
+                prefix=self.TEST_OBJ_PREFIX
+            )
             self.admin_client.put_object(self.bucket, self.test_obj_key, "test_data")
 
     def do_operation(self, s3_client, bucket):

--- a/framework/bucket_policies/access_validation_strategies/get_bucket_policy_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/get_bucket_policy_validation_strategy.py
@@ -1,0 +1,16 @@
+from framework.bucket_policies.access_validation_strategies.policy_operation_validation_strategy import (
+    PolicyOperationValidationStrategy,
+)
+
+
+class GetBucketPolicyValidationStrategy(PolicyOperationValidationStrategy):
+    """
+    A strategy for validating access to the GetBucketPolicy operation
+    """
+
+    @property
+    def expected_success_code(self):
+        return 200
+
+    def do_operation(self, s3_client, bucket):
+        return s3_client.get_bucket_policy(bucket)

--- a/framework/bucket_policies/access_validation_strategies/get_object_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/get_object_validation_strategy.py
@@ -17,7 +17,9 @@ class GetObjectValidationStrategy(AccessValidationStrategy):
         if "obj_key" in setup_kwargs:
             self.test_obj_key = setup_kwargs["obj_key"]
         else:
-            self.test_obj_key = generate_unique_resource_name(prefix="test-obj-")
+            self.test_obj_key = generate_unique_resource_name(
+                prefix=self.TEST_OBJ_PREFIX
+            )
             self.admin_client.put_object(self.bucket, self.test_obj_key, "test_data")
 
     def do_operation(self, s3_client, bucket, **setup_kwargs):

--- a/framework/bucket_policies/access_validation_strategies/head_object_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/head_object_validation_strategy.py
@@ -17,7 +17,9 @@ class HeadObjectValidationStrategy(AccessValidationStrategy):
         if "obj_key" in setup_kwargs:
             self.test_obj_key = setup_kwargs["obj_key"]
         else:
-            self.test_obj_key = generate_unique_resource_name(prefix="test-obj-")
+            self.test_obj_key = generate_unique_resource_name(
+                prefix=self.TEST_OBJ_PREFIX
+            )
             self.admin_client.put_object(self.bucket, self.test_obj_key, "test_data")
 
     def do_operation(self, s3_client, bucket, **setup_kwargs):

--- a/framework/bucket_policies/access_validation_strategies/list_bucket_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/list_bucket_validation_strategy.py
@@ -14,7 +14,7 @@ class ListBucketValidationStrategy(AccessValidationStrategy):
         return 200
 
     def setup(self, **setup_kwargs):
-        obj_key = generate_unique_resource_name(prefix="test-obj-")
+        obj_key = generate_unique_resource_name(prefix=self.TEST_OBJ_PREFIX)
         self.admin_client.put_object(self.bucket, obj_key, "test_data")
 
     def do_operation(self, s3_client, bucket):

--- a/framework/bucket_policies/access_validation_strategies/policy_operation_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/policy_operation_validation_strategy.py
@@ -1,0 +1,33 @@
+from framework.bucket_policies.access_validation_strategies.access_validation_strategy_interface import (
+    AccessValidationStrategy,
+)
+from framework.bucket_policies.bucket_policy import BucketPolicy
+
+
+from botocore.exceptions import ClientError
+
+
+from abc import ABC
+
+
+class PolicyOperationValidationStrategy(AccessValidationStrategy, ABC):
+    """
+    An abstract subclass for strategies used in validating access to bucket policy operations
+    """
+
+    def setup(self, **setup_kwargs):
+        if "policy" in setup_kwargs:
+            self.test_policy = setup_kwargs["policy"]
+        else:
+            self.test_policy = BucketPolicy.default_template()
+
+        try:
+            self.original_policy = BucketPolicy.from_json(
+                self.admin_client.get_bucket_policy(self.bucket).get("Policy")
+            )
+        except ClientError as e:
+            self.original_policy = None
+
+    def cleanup(self):
+        if self.original_policy:
+            self.admin_client.put_bucket_policy(self.bucket, str(self.original_policy))

--- a/framework/bucket_policies/access_validation_strategies/put_bucket_policy_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/put_bucket_policy_validation_strategy.py
@@ -1,0 +1,26 @@
+from framework.bucket_policies.access_validation_strategies.policy_operation_validation_strategy import (
+    PolicyOperationValidationStrategy,
+)
+from framework.bucket_policies.bucket_policy import BucketPolicyBuilder
+
+
+class PutBucketPolicyValidationStrategy(PolicyOperationValidationStrategy):
+    """
+    A strategy for validating access to the PutBucketPolicy operation
+    """
+
+    @property
+    def expected_success_code(self):
+        return 200
+
+    def do_operation(self, s3_client, bucket):
+
+        test_policy = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_principal("*")
+            .add_action("PutBucketPolicy")
+            .add_resource("*")
+            .build()
+        )
+        return s3_client.put_bucket_policy(bucket, str(test_policy))

--- a/framework/bucket_policies/access_validation_strategies/put_object_validation_strategy.py
+++ b/framework/bucket_policies/access_validation_strategies/put_object_validation_strategy.py
@@ -14,5 +14,5 @@ class PutObjectValidationStrategy(AccessValidationStrategy):
         return 200
 
     def do_operation(self, s3_client, bucket):
-        obj_key = generate_unique_resource_name(prefix="test-obj-")
+        obj_key = generate_unique_resource_name(prefix=self.TEST_OBJ_PREFIX)
         return s3_client.put_object(bucket, obj_key, "test_data")

--- a/framework/bucket_policies/access_validation_strategy_factory.py
+++ b/framework/bucket_policies/access_validation_strategy_factory.py
@@ -37,9 +37,11 @@ class AccessValidationStrategyFactory:
 
         # Dynamically import the strategy module
         try:
-            prefix = "framework.bucket_policies.access_validation_strategies."
-            module = prefix + camel_to_snake(operation) + "_validation_strategy"
-            strategy_module = importlib.import_module(module)
+            # __package__ is the parent package of the current module
+            package = __package__ + ".access_validation_strategies"
+            module = camel_to_snake(operation) + "_validation_strategy"
+            full_module_path = package + "." + module
+            strategy_module = importlib.import_module(full_module_path)
         except ImportError:
             raise NotImplementedError(
                 f"No strategy module found for operation: {operation}"
@@ -51,7 +53,7 @@ class AccessValidationStrategyFactory:
             concrete_strategy_subclass = getattr(strategy_module, class_name)
         except AttributeError:
             raise NotImplementedError(
-                f"Strategy class {class_name} not found in module {module}"
+                f"Strategy class {class_name} not found in {full_module_path}"
             )
 
         # Create an instance of the strategy class

--- a/tests/bucket_policies/test_bucket_policies.py
+++ b/tests/bucket_policies/test_bucket_policies.py
@@ -254,3 +254,76 @@ class TestBucketPolicies:
                 f"{op} was {'denied' if not can_access else 'allowed'}"
                 f" for the new account after only allowing {tested_op}"
             )
+
+    @pytest.mark.parametrize(
+        "access_effect",
+        [
+            "Allow",
+            # "Deny", Skipped due to https://bugzilla.redhat.com/show_bug.cgi?id=2280212
+        ],
+    )
+    def test_resource_access_policies(
+        self, c_scope_s3client, s3_client_factory, access_effect
+    ):
+        """
+        Test bucket policies that modify access to specific resources:
+        1. Setup: create a bucket and put objects in it
+        2. Apply a bucket policy that modifies access to the first object
+            2.1 Build the policy with an Allow or Deny statement
+            2.2 Apply the policy
+        3. Check that the account has the expected access for each object
+            - Check multiple operations for each object
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        test_objs = c_scope_s3client.put_random_objects(bucket, 2)
+
+        # Use an account which is allowed/denied all access to the bucket by default
+        tested_client = (
+            s3_client_factory() if access_effect == "Allow" else c_scope_s3client
+        )
+        # 2. Apply a bucket policy that modifies access to the first object
+        # 2.1 Build the policy with an Allow or Deny statement
+        bpb = BucketPolicyBuilder()
+        bpb = (
+            bpb.add_allow_statement()
+            if access_effect == "Allow"
+            else bpb.add_deny_statement()
+        )
+        policy = (
+            bpb.add_action("*")
+            .add_principal("*")
+            .add_resource(f"{bucket}/{test_objs[0]}")
+            .build()
+        )
+
+        # 2.2 Apply the policy
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the account has the expected access for each object
+        first_obj_access_expectation = access_effect == "Allow"
+        access_expectations = [
+            first_obj_access_expectation,
+            not first_obj_access_expectation,
+        ]
+        # Check multiple operations for each object
+        access_tester = S3OperationAccessTester(admin_client=c_scope_s3client)
+        for i, obj in enumerate(test_objs):
+            for op in [
+                "GetObject",
+                "DeleteObject",
+            ]:
+                can_access = access_tester.check_client_access_to_bucket_op(
+                    tested_client, bucket, op, obj_key=obj
+                )
+                assert can_access == access_expectations[i], (
+                    f"Access was {'allowed' if access_expectations[i] else 'denied'}"
+                    " to the object when it shouldn't have been:\n"
+                    f"operation={op}, object={obj}\n"
+                    f"expected access={access_expectations[i]}\n"
+                    f"actual access={can_access}\n"
+                )

--- a/tests/bucket_policies/test_bucket_policies.py
+++ b/tests/bucket_policies/test_bucket_policies.py
@@ -153,6 +153,8 @@ class TestBucketPolicies:
             "PutObject",
             "DeleteObject",
             "ListBucket",
+            "PutBucketPolicy",
+            "GetBucketPolicy",
         ],
     )
     def test_operation_access_policies(

--- a/tests/bucket_policies/test_multi_bucket_policies.py
+++ b/tests/bucket_policies/test_multi_bucket_policies.py
@@ -1,0 +1,214 @@
+from framework.bucket_policies.bucket_policy import BucketPolicyBuilder
+from framework.bucket_policies.s3_operation_access_tester import S3OperationAccessTester
+
+
+class TestMultiBucketPolicies:
+    """
+    Test complex bucket policies that address multiple properties in a single policy.
+
+    """
+
+    def test_multi_statement_policy(self, c_scope_s3client, s3_client_factory):
+        """
+        Test multi-statement bucket policies:
+
+        1. Setup:
+            1.1 Create a bucket
+            1.2 Put two objects in the bucket
+            1.3 Create a new account
+        2. Apply a multi-statement policy to a bucket:
+            2.1 Allow all accounts all access to a bucket's objects
+            2.2 Deny all access to a specific object
+            2.3 Apply the policy
+        3. Check that the two statements were applied correctly:
+            3.1 Check that the new account can access the allowed object
+            3.2 Check that the new account can't access the denied object
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        denied_obj, allowed_obj = c_scope_s3client.put_random_objects(bucket, 2)
+        new_acc_client = s3_client_factory()
+
+        # 2. Apply a multi-statement policy
+        # 2.1 Allow all accounts all access to a bucket's objects
+        bpb = BucketPolicyBuilder()
+        bpb = (
+            bpb.add_allow_statement()
+            .add_action("*")
+            .add_principal("*")
+            .add_resource(f"{bucket}/*")
+        )
+        # 2.2 Deny all access to a specific object
+        bpb = (
+            bpb.add_deny_statement()
+            .add_action("*")
+            .add_principal("*")
+            .add_resource(f"{bucket}/{denied_obj}")
+        )
+        policy = bpb.build()
+
+        # 2.3 Apply the policy
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the two statements are applied correctly
+        # 3.1 Check that a new account can access the allowed object
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        assert access_tester.check_client_access_to_bucket_op(
+            new_acc_client, bucket, "GetObject", obj_key=allowed_obj
+        ), "Access was denied to the allowed object"
+        # 3.2 Check that the original account can't access the denied object
+        assert not access_tester.check_client_access_to_bucket_op(
+            new_acc_client, bucket, "GetObject", obj_key=denied_obj
+        ), "Access was allowed to the denied object"
+
+    def test_multi_operation_statement_policy(
+        self, c_scope_s3client, s3_client_factory
+    ):
+        """
+        Test multi-operation statement policies:
+
+        1. Setup:
+            1.1 Create a bucket
+            1.2 Create a new account
+        2. Apply a multi-operation statement policy to a bucket
+            2.1 Build a policy that allows multiple operations to all accounts
+            2.2 Apply the policy
+        3. Check that the new account can perform the allowed operations
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        new_acc_client = s3_client_factory()
+
+        # 2. Apply a multi-action statement policy
+        # 2.1 Build a policy that allows multiple operations to all accounts
+        tested_ops = ["GetObject", "PutObject", "DeleteObject"]
+        bpb = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_principal("*")
+            .add_resource(f"{bucket}/*")
+        )
+        for op in tested_ops:
+            bpb.add_action(op)
+        policy = bpb.build()
+
+        # 2.2 Apply the policy
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the new account can perform the allowed operations
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        for op in tested_ops:
+            assert access_tester.check_client_access_to_bucket_op(
+                new_acc_client, bucket, op
+            ), f"{op} was denied for the account when it shouldn't have been"
+
+    def test_multi_resource_statement_policy(self, c_scope_s3client, s3_client_factory):
+        """
+        Test multi-resource statement policies:
+
+        1. Setup:
+            1.1 Create a bucket
+            1.2 Put multiple objects in the bucket
+            1.3 Create a new account
+        2. Apply a multi-resource statement policy to a bucket
+            2.1 Build a policy that allows access to multiple objects to all accounts
+            2.2 Apply the policy
+        3. Check that access is allowed to all objects
+
+        """
+
+        # 1. Setup
+        new_acc_client = s3_client_factory()
+        bucket = c_scope_s3client.create_bucket()
+        tested_objs = c_scope_s3client.put_random_objects(bucket, 5)
+
+        # 1. Apply a multi-resource statement policy
+        # 1.1 Build a policy that allows access to multiple objects to all accounts
+        bpb = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_principal("*")
+            .add_action("*")
+        )
+        for obj in tested_objs:
+            bpb.add_resource(f"{bucket}/{obj}")
+        policy = bpb.build()
+
+        # 2.2 Apply the policy
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that access is denied to all objects
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        for obj in tested_objs:
+            assert access_tester.check_client_access_to_bucket_op(
+                new_acc_client, bucket, "GetObject", obj_key=obj
+            ), f"Access was denied to {obj} when it shouldn't have been"
+
+    def test_multi_principal_statement_policy(
+        self, c_scope_s3client, account_manager, s3_client_factory
+    ):
+        """
+        Test multi-principal statement policies:
+
+        1. Setup:
+            1.1 Create a bucket
+            1.2 Create multiple accounts
+        2. Apply a multi-principal statement policy to a bucket:
+            2.1 Build a policy that allows multiple principals access to a bucket
+            2.2 Apply the policy
+        3. Check that all principals are allowed access
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        acc_names, acc_clients = [], []
+        for _ in range(3):
+            acc_name, access_key, secret_key = account_manager.create()
+            acc_names.append(acc_name)
+            acc_clients.append(
+                s3_client_factory(access_and_secret_keys_tuple=(access_key, secret_key))
+            )
+
+        # 2. Apply a multi-principal statement policy
+        # 2.1 Build a policy that allows multiple principals access to a bucket
+        bpb = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_action("*")
+            .add_resource(f"{bucket}/*")
+        )
+        for acc_name in acc_names:
+            bpb.add_principal(acc_name)
+        policy = bpb.build()
+
+        # 2.2 Apply the policy
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that all principals are allowed access
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        for acc, s3_client in zip(acc_names, acc_clients):
+            assert access_tester.check_client_access_to_bucket_op(
+                s3_client, bucket, "GetObject"
+            ), f"Access was denied for account {acc} when it shouldn't have been"

--- a/tests/bucket_policies/test_not_bucket_policies.py
+++ b/tests/bucket_policies/test_not_bucket_policies.py
@@ -1,0 +1,148 @@
+from framework.bucket_policies.bucket_policy import BucketPolicyBuilder
+from framework.bucket_policies.s3_operation_access_tester import S3OperationAccessTester
+
+
+class TestNotBucketPolicies:
+    """
+    Test bucket policies that use the NotPrincipal, NotAction, and NotResource fields
+
+    """
+
+    def test_not_principal_bucket_policy(
+        self, c_scope_s3client, account_manager, s3_client_factory
+    ):
+        """
+        Test the NotPrincipal field in a bucket policy:
+        1. Setup:
+            1.1 Create a bucket using the admin client
+            1.2 Create two accounts
+        2. Allow all access to all principals except for the account specified by NotPrincipal
+        3. Check that the allowed account can access the bucket
+        4. Check that the denied account cannot access the bucket
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        allowed_client = s3_client_factory()
+        denied_acc_name, access_key, secret_key = account_manager.create()
+        denied_client = s3_client_factory(
+            access_and_secret_keys_tuple=(access_key, secret_key)
+        )
+
+        # 2. Alllow all access to all principals except the account specified by NotPrincipal
+        policy = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_resource(f"{bucket}/*")
+            .add_action("*")
+            .add_not_principal(denied_acc_name)
+            .build()
+        )
+
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the allowed account can access the bucket
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        assert access_tester.check_client_access_to_bucket_op(
+            allowed_client, bucket, "GetObject"
+        ), "Access was denied for the allowed account"
+
+        # 4. Check that the denied account cannot access the bucket
+        assert not access_tester.check_client_access_to_bucket_op(
+            denied_client, bucket, "GetObject"
+        ), "The denied account was allowed acces when it shouldn't have been"
+
+    def test_not_action_bucket_policy(self, c_scope_s3client, s3_client_factory):
+        """
+        Test the NotAction field in a bucket policy:
+        1. Setup:
+            1.1 Create a bucket using the admin client
+            1.2 Create a new account
+        2. Allow all actions on the bucket's objects except for DeleteObject
+        3. Check that the DeleteObject action is denied
+        4. Check that other operations are allowed
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        new_acc_client = s3_client_factory()
+
+        # 2. Allow all actions on the bucket's objects except for DeleteObject
+        policy = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_resource(f"{bucket}/*")
+            .add_principal("*")
+            .add_not_action("DeleteObject")
+            .build()
+        )
+
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the DeleteObject action is denied
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+        assert not access_tester.check_client_access_to_bucket_op(
+            new_acc_client, bucket, "DeleteObject"
+        ), "DeleteObject was allowed when it should have been denied"
+
+        # 4. Check that other actions are allowed
+        for op in ["GetObject", "PutObject"]:
+            assert access_tester.check_client_access_to_bucket_op(
+                new_acc_client, bucket, op
+            ), f"{op} was denied when it shouldn't have been"
+
+    def test_not_resource_bucket_policy(self, c_scope_s3client, s3_client_factory):
+        """
+        Test the NotResource field in a bucket policy:
+        1. Setup:
+            1.1 Create a bucket using the admin client
+            1.2 Create a new account
+        2. Allow access to all objects on the bucket except for the object specified by NotResource
+        3. Check that the object specified by NotResource is still inaccessible
+        4. Check that access to the other object is allowed
+
+        """
+        # 1. Setup
+        bucket = c_scope_s3client.create_bucket()
+        new_acc_client = s3_client_factory()
+        access_tester = S3OperationAccessTester(
+            admin_client=c_scope_s3client,
+        )
+
+        denied_obj, allowed_obj = c_scope_s3client.put_random_objects(bucket, 2)
+
+        # 2. Allow access to all objects on the bucket except for the
+        # object specified by NotResource
+        policy = (
+            BucketPolicyBuilder()
+            .add_allow_statement()
+            .add_action("*")
+            .add_principal("*")
+            .add_not_resource(f"{bucket}/{denied_obj}")
+            .build()
+        )
+
+        response = c_scope_s3client.put_bucket_policy(bucket, str(policy))
+        assert (
+            response["Code"] == 200
+        ), f"put_bucket_policy failed with code {response['Code']}"
+
+        # 3. Check that the object specified by NotResource is still inaccessible
+        assert not access_tester.check_client_access_to_bucket_op(
+            new_acc_client, bucket, "GetObject", obj_key=denied_obj
+        ), f"Access to {denied_obj} was allowed when it should have been denied"
+
+        # 4. Check that access to the other object is allowed
+        assert access_tester.check_client_access_to_bucket_op(
+            new_acc_client, bucket, "GetObject", obj_key=allowed_obj
+        ), f"Acess to {allowed_obj} was denied when it should have been allowed"


### PR DESCRIPTION
This PR adds more bucket policy tests:

- test_operation_access_policies[PutBucketPolicy-Allow/Deny]
- test_operation_access_policies[GetBucketPolicy-Allow/Deny]
- test_resource_access_policies[Allow/Deny]
- test_multi_statement_policy
- test_multi_operation_statement_policy
- test_multi_resource_statement_policy
- test_multi_principal_statement_policy
- test_not_principal_bucket_policy
- test_not_action_bucket_policy
- test_not_resource_bucket_policy