### PR TITLE
Update the allow_bucket_creation=False test

### DIFF
--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -68,6 +68,7 @@ class NSFSAccount(Account):
         secret_key="",
         config_root=None,
         fs_backend=constants.DEFAULT_FS_BACKEND,
+        allow_bucket_creation=True,
     ):
         """
         Account creation using file
@@ -76,12 +77,9 @@ class NSFSAccount(Account):
             account_name (str): name of the account
             access_key (str): access key for the account
             secret_key (str): secret key for the account
-            email (str): email for the account
-            allow_bucket_creation (bool): allow bucket creation
-            uid (int): user ID
-            gid (int): group ID
             config_root (str): path to config root
             fs_backend (str): filesystem backend
+            allow_bucket_creation (bool): allow bucket creation
 
         Returns:
             tuple:
@@ -115,6 +113,7 @@ class NSFSAccount(Account):
             "secret_key": secret_key,
             "bucket_path": bucket_path,
             "fs_backend": fs_backend,
+            "allow_bucket_creation": allow_bucket_creation,
         }
         account_data_full = templating.render_template(account_template, account_data)
         log.info(f"account content: {account_data_full}")

--- a/templates/account.json
+++ b/templates/account.json
@@ -1,6 +1,6 @@
 {
     "name": "{{account_name}}",
-    "allow_bucket_creation": "true",
+    "allow_bucket_creation": "{{allow_bucket_creation}}",
     "access_key": "{{access_key}}",
     "secret_key": "{{secret_key}}",
     "uid": 0,

--- a/tests/test_s3_bucket_operations.py
+++ b/tests/test_s3_bucket_operations.py
@@ -99,20 +99,20 @@ class TestS3BucketOperations:
         ), "Bucket creation did not fail with the expected error"
 
         # 2. Test creating a bucket using the credentials of a user that's not allowed to create buckets
-
-        # TODO: Comment out once https://bugzilla.redhat.com/show_bug.cgi?id=2262992 is fixed
-        # _, restricted_acc_access_key, restricted_acc_secret_key = (
-        #     account_manager.create(allow_bucket_creation=False)
-        # )
-        # restricted_s3_client = s3_client_factory(
-        #     access_and_secret_keys_tuple=(
-        #         restricted_acc_access_key,
-        #         restricted_acc_secret_key,
-        #     )
-        # )
-        # with pytest.raises(AccessDeniedException):
-        #     restricted_s3_client.create_bucket()
-        #     log.error("Attempting to create a bucket with restricted credentials did not fail as expected")
+        _, restricted_acc_access_key, restricted_acc_secret_key = (
+            account_manager.create(allow_bucket_creation=False)
+        )
+        restricted_s3_client = s3_client_factory(
+            access_and_secret_keys_tuple=(
+                restricted_acc_access_key,
+                restricted_acc_secret_key,
+            )
+        )
+        response = restricted_s3_client.create_bucket(get_response=True)
+        assert (
+            response["Code"] == "AccessDenied",
+            "Bucket creatoin succeeded with a user that's not allowed to create buckets",
+        )
 
     def test_expected_bucket_deletion_failures(self, c_scope_s3client):
         """


### PR DESCRIPTION
This PR also adds the `allow_bucket_creation` argument to the account factory, and uses it to finalize `test_expected_bucket_creation_failures` now that https://bugzilla.redhat.com/show_bug.cgi?id=2262992 is fixed. 

