### PR TITLE
Add tier pytest marks and decorators to noobaa-sa-ci

### DIFF
--- a/framework/customizations/marks.py
+++ b/framework/customizations/marks.py
@@ -1,0 +1,16 @@
+import pytest
+
+# tier1 - basic functionality testing of core features
+tier1 = pytest.mark.tier1(value=1)
+
+# tier2 - testing core features with the addition of complexity
+tier2 = pytest.mark.tier2(value=2)
+
+# tier3 - edge cases and negative testing
+tier3 = pytest.mark.tier3(value=3)
+
+# tier4 - disruptive testing
+tier4 = pytest.mark.tier4(value=4)
+
+# build acceptance critieria
+acceptance = pytest.mark.acceptance

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,11 @@
 [pytest]
 addopts = --show-capture=no --capture=no
+markers =     
+    tier1: marker for tier1 tests
+    tier2: marker for tier2 tests
+    tier3: marker for tier3 tests
+    tier4: marker for tier4 tests
+    acceptance: marker for acceptance tests
 
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/bucket_policies/test_bucket_policies.py
+++ b/tests/bucket_policies/test_bucket_policies.py
@@ -6,6 +6,7 @@ import pytest
 
 from framework.bucket_policies.bucket_policy import BucketPolicy, BucketPolicyBuilder
 from framework.bucket_policies.s3_operation_access_tester import S3OperationAccessTester
+from framework.customizations.marks import tier1, tier2, tier3
 from noobaa_sa import constants
 
 log = logging.getLogger(__name__)
@@ -17,6 +18,7 @@ class TestBucketPolicies:
 
     """
 
+    @tier1
     def test_bucket_policy_put_get_delete(self, c_scope_s3client):
         """
         Test the basic s3 bucket policy operations using a valid policy template:
@@ -49,6 +51,7 @@ class TestBucketPolicies:
             response["ResponseMetadata"]["HTTPStatusCode"] == 204
         ), "delete_bucket_policy failed"
 
+    @tier3
     @pytest.mark.parametrize(
         "invalidate",
         [
@@ -103,6 +106,7 @@ class TestBucketPolicies:
         response = c_scope_s3client.put_bucket_policy(bucket, str(valid_bucket_policy))
         assert response["Code"] == 200, "get_bucket_policy failed"
 
+    @tier3
     @pytest.mark.parametrize(
         "operation",
         [
@@ -139,6 +143,7 @@ class TestBucketPolicies:
             other_acc_s3_client, bucket, operation
         ), f"{operation} was allowed for a different account by default"
 
+    @tier2
     @pytest.mark.parametrize(
         "access_effect",
         [
@@ -255,6 +260,7 @@ class TestBucketPolicies:
                 f" for the new account after only allowing {tested_op}"
             )
 
+    @tier1
     @pytest.mark.parametrize(
         "access_effect",
         [

--- a/tests/bucket_policies/test_multi_bucket_policies.py
+++ b/tests/bucket_policies/test_multi_bucket_policies.py
@@ -1,5 +1,6 @@
 from framework.bucket_policies.bucket_policy import BucketPolicyBuilder
 from framework.bucket_policies.s3_operation_access_tester import S3OperationAccessTester
+from framework.customizations.marks import tier1
 
 
 class TestMultiBucketPolicies:
@@ -8,6 +9,7 @@ class TestMultiBucketPolicies:
 
     """
 
+    @tier1
     def test_multi_statement_policy(self, c_scope_s3client, s3_client_factory):
         """
         Test multi-statement bucket policies:
@@ -67,6 +69,7 @@ class TestMultiBucketPolicies:
             new_acc_client, bucket, "GetObject", obj_key=denied_obj
         ), "Access was allowed to the denied object"
 
+    @tier1
     def test_multi_operation_statement_policy(
         self, c_scope_s3client, s3_client_factory
     ):
@@ -114,6 +117,7 @@ class TestMultiBucketPolicies:
                 new_acc_client, bucket, op
             ), f"{op} was denied for the account when it shouldn't have been"
 
+    @tier1
     def test_multi_resource_statement_policy(self, c_scope_s3client, s3_client_factory):
         """
         Test multi-resource statement policies:
@@ -161,6 +165,7 @@ class TestMultiBucketPolicies:
                 new_acc_client, bucket, "GetObject", obj_key=obj
             ), f"Access was denied to {obj} when it shouldn't have been"
 
+    @tier1
     def test_multi_principal_statement_policy(
         self, c_scope_s3client, account_manager, s3_client_factory
     ):

--- a/tests/bucket_policies/test_not_bucket_policies.py
+++ b/tests/bucket_policies/test_not_bucket_policies.py
@@ -1,5 +1,6 @@
 from framework.bucket_policies.bucket_policy import BucketPolicyBuilder
 from framework.bucket_policies.s3_operation_access_tester import S3OperationAccessTester
+from framework.customizations.marks import tier1
 
 
 class TestNotBucketPolicies:
@@ -8,6 +9,7 @@ class TestNotBucketPolicies:
 
     """
 
+    @tier1
     def test_not_principal_bucket_policy(
         self, c_scope_s3client, account_manager, s3_client_factory
     ):
@@ -57,6 +59,7 @@ class TestNotBucketPolicies:
             denied_client, bucket, "GetObject"
         ), "The denied account was allowed acces when it shouldn't have been"
 
+    @tier1
     def test_not_action_bucket_policy(self, c_scope_s3client, s3_client_factory):
         """
         Test the NotAction field in a bucket policy:
@@ -101,6 +104,7 @@ class TestNotBucketPolicies:
                 new_acc_client, bucket, op
             ), f"{op} was denied when it shouldn't have been"
 
+    @tier1
     def test_not_resource_bucket_policy(self, c_scope_s3client, s3_client_factory):
         """
         Test the NotResource field in a bucket policy:

--- a/tests/test_account_operations.py
+++ b/tests/test_account_operations.py
@@ -3,12 +3,14 @@ import logging
 from common_ci_utils.random_utils import generate_unique_resource_name
 
 from framework import config
+from framework.customizations.marks import tier1
 from noobaa_sa import constants
 from utility.utils import generate_random_key
 
 log = logging.getLogger(__name__)
 
 
+@tier1
 def test_account_operations(account_manager):
     # account operations
     account_name = generate_unique_resource_name(prefix="account")

--- a/tests/test_bucket_operations.py
+++ b/tests/test_bucket_operations.py
@@ -4,12 +4,14 @@ import os
 from common_ci_utils.random_utils import generate_unique_resource_name
 
 from framework.ssh_connection_manager import SSHConnectionManager
+from framework.customizations.marks import tier1
 from noobaa_sa import constants
 from utility.utils import generate_random_key, get_noobaa_sa_host_home_path
 
 log = logging.getLogger(__name__)
 
 
+@tier1
 def test_bucket_operations(account_manager, bucket_manager):
     # Create SSH connection
     conn = SSHConnectionManager().connection

--- a/tests/test_health_operations.py
+++ b/tests/test_health_operations.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from common_ci_utils.random_utils import generate_unique_resource_name
+from framework.customizations.marks import tier1
 from noobaa_sa import constants
 from utils.utils import get_noobaa_health_status
 from utility.utils import generate_random_key
@@ -26,6 +27,7 @@ class Test_health_operations:
         bucket_manager.create(account_name, bucket_name)
 
     # Noobaa port health operation
+    @tier1
     @pytest.mark.parametrize(
         argnames="flag",
         argvalues=[
@@ -60,6 +62,7 @@ class Test_health_operations:
         log.info(get_info)
 
     # Noobaa account health operation
+    @tier1
     @pytest.mark.parametrize(
         argnames="flag",
         argvalues=[
@@ -108,6 +111,7 @@ class Test_health_operations:
         log.info(get_info)
 
     # Noobaa bucket health operation
+    @tier1
     @pytest.mark.parametrize(
         argnames="flag",
         argvalues=[

--- a/tests/test_multipart_operations.py
+++ b/tests/test_multipart_operations.py
@@ -1,6 +1,7 @@
 import logging
 
 from utility.bucket_utils import upload_incomplete_multipart_object
+from framework.customizations.marks import tier1
 from utility.utils import check_data_integrity
 
 log = logging.getLogger(__name__)
@@ -11,6 +12,7 @@ class TestMultipartOperations:
     Test S3 object multipart operations on NSFS
     """
 
+    @tier1
     def test_multipart_upload(
         self,
         c_scope_s3client,
@@ -39,6 +41,7 @@ class TestMultipartOperations:
         ), "Failed to upload multipart object"
         log.info(mp_response)
 
+    @tier1
     def test_multipart_download(self, c_scope_s3client, tmp_directories_factory):
         """
         Test basic s3 operations using a noobaa bucket:
@@ -64,6 +67,7 @@ class TestMultipartOperations:
         assert check_data_integrity(resp["origin_dir"], resp["results_dir"])
         log.info("Both uploaded and downloaded data are identical")
 
+    @tier1
     def test_list_multipart_objects(self, c_scope_s3client, tmp_directories_factory):
         """
         Test multipart object list operations using BOTO s3:
@@ -91,6 +95,7 @@ class TestMultipartOperations:
         ), "All uploaded objects are not present in bucket"
         log.info("Uploaded objects are present in bucket")
 
+    @tier1
     def test_multipart_list_parts(self, c_scope_s3client, tmp_directories_factory):
         """
         Test multipart object list operations using BOTO s3:
@@ -120,6 +125,7 @@ class TestMultipartOperations:
         log.info(mp_response)
         log.info("Multipart operation is completed")
 
+    @tier1
     def test_list_multipart_uploads(self, c_scope_s3client, tmp_directories_factory):
         """
         Test multipart object list operations using BOTO s3:
@@ -151,6 +157,7 @@ class TestMultipartOperations:
         log.info(mp_response)
         log.info("Multipart operation is completed")
 
+    @tier1
     def test_multipart_upload_part_copy(
         self, c_scope_s3client, tmp_directories_factory
     ):
@@ -200,6 +207,7 @@ class TestMultipartOperations:
         )
         log.info("Multipart operation is completed using upload_part_copy method")
 
+    @tier1
     def test_s3_multipart_abort_upload(self, c_scope_s3client, tmp_directories_factory):
         """
         Test multipart object list operations using BOTO s3:

--- a/tests/test_s3_bucket_operations.py
+++ b/tests/test_s3_bucket_operations.py
@@ -1,5 +1,6 @@
 import logging
 
+from framework.customizations.marks import tier1, tier3
 from common_ci_utils.random_utils import generate_unique_resource_name
 
 log = logging.getLogger(__name__)
@@ -10,6 +11,7 @@ class TestS3BucketOperations:
     Test S3 bucket operations using NSFS
     """
 
+    @tier1
     def test_bucket_creation_deletion_and_head(self, c_scope_s3client):
         """
         Test bucket creation and deletion via S3:
@@ -40,6 +42,7 @@ class TestS3BucketOperations:
         response = c_scope_s3client.head_bucket(bucket_name)
         assert response["Code"] == 404, "Bucket was not deleted"
 
+    @tier1
     def test_list_buckets(self, c_scope_s3client):
         """
         Test listing buckets before creation and after deletion via S3
@@ -82,6 +85,7 @@ class TestS3BucketOperations:
             log.error(f"Listed buckets: {listed_buckets}")
             raise e
 
+    @tier3
     def test_expected_bucket_creation_failures(
         self, c_scope_s3client, account_manager, s3_client_factory
     ):
@@ -114,6 +118,7 @@ class TestS3BucketOperations:
         #     restricted_s3_client.create_bucket()
         #     log.error("Attempting to create a bucket with restricted credentials did not fail as expected")
 
+    @tier3
     def test_expected_bucket_deletion_failures(self, c_scope_s3client):
         """
         Test bucket deletion scenarios that are expected to fail:

--- a/tests/test_s3_object_operations.py
+++ b/tests/test_s3_object_operations.py
@@ -4,6 +4,7 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from framework.customizations.marks import tier1, tier2, tier3
 from common_ci_utils.file_system_utils import compare_md5sums
 from common_ci_utils.random_utils import (
     generate_random_files,
@@ -19,6 +20,7 @@ class TestS3ObjectOperations:
     Test S3 object operations using NSFS
     """
 
+    @tier1
     @pytest.mark.parametrize("use_v2", [False, True])
     def test_list_objects(self, c_scope_s3client, tmp_directories_factory, use_v2):
         """
@@ -81,6 +83,7 @@ class TestS3ObjectOperations:
                 f"Object: {written}, Expected: {expected_size}, Actual: {listed_size}",
             )
 
+    @tier1
     @pytest.mark.parametrize(
         "put_method",
         [
@@ -125,6 +128,7 @@ class TestS3ObjectOperations:
                 original_file_content == downloaded_obj_data
             ), "Retrieved object content does not match"
 
+    @tier1
     def test_object_deletion(self, c_scope_s3client):
         """
         Test the S3 DeleteObject and DeleteObjects operations:
@@ -170,6 +174,7 @@ class TestS3ObjectOperations:
             written_objects[5:] == post_deletion_objects
         ), "Non deleted objects were not listed post deletion"
 
+    @tier1
     def test_copy_object(self, c_scope_s3client):
         """
         Test the S3 CopyObject operation:
@@ -220,6 +225,7 @@ class TestS3ObjectOperations:
         )
         assert obj_data_body == copied_obj_data, "Copied object content does not match"
 
+    @tier1
     def test_data_integrity(self, c_scope_s3client, tmp_directories_factory):
         """
         Test data integrity of objects written and read via S3:
@@ -259,6 +265,7 @@ class TestS3ObjectOperations:
             md5sums_match = compare_md5sums(original_full_path, downloaded_full_path)
             assert md5sums_match, f"MD5 sums do not match for {original}"
 
+    @tier3
     def test_expected_put_and_get_failures(self, c_scope_s3client):
         """
         Test S3 PutObject and GetObject operations that are expected to fail:
@@ -284,6 +291,7 @@ class TestS3ObjectOperations:
             response,
         )
 
+    @tier3
     def test_expected_copy_failures(self, c_scope_s3client):
         """
         Test S3 CopyObject operations that are expected to fail:


### PR DESCRIPTION
To make use of the new marks, use the `-m` option in the same way you would on Pytest or OCS-CI.