### PR TITLE
Removes support of testing health flag with default values

### DIFF
--- a/noobaa_sa/defaults.py
+++ b/noobaa_sa/defaults.py
@@ -2,4 +2,4 @@ import os
 
 NOOBAA_SA_SRC = "/usr/local/noobaa-core"
 MANAGE_NSFS = os.path.join(NOOBAA_SA_SRC, "src/deploy/noobaa-cli")
-HEALTH = os.path.join(NOOBAA_SA_SRC, "src/cmd/health")
+HEALTH = os.path.join(NOOBAA_SA_SRC, "src/deploy/noobaa-cli diagnose health")

--- a/tests/test_health_operations.py
+++ b/tests/test_health_operations.py
@@ -36,15 +36,9 @@ class Test_health_operations:
                         "https_port": 6443
                     },
             ),
-            pytest.param(
-                    {
-                        "https_port": None
-                    },
-            )
         ],
         ids=[
              "custom_value",
-             "default_value",
         ],
     )
     def test_noobaa_port_flag(self, setup_prereqs, flag):
@@ -76,16 +70,10 @@ class Test_health_operations:
                         "all_account_details": False
                     },
             ),
-            pytest.param(
-                    {
-                        "all_account_details": None
-                    },
-            ),
         ],
         ids=[
              "true_value",
              "false_value",
-             "default_value",
         ],
     )
     def test_noobaa_account_flag(self, setup_prereqs, flag):
@@ -100,11 +88,11 @@ class Test_health_operations:
             raise e.HealthStatusFailed(
                     f"Health check failed for get all account with error {get_info['error']['error_code']}"
                 )
-        if flag.get('all_account_details') is True and len(get_info['checks']['accounts_status']['valid_accounts']) == 0:
+        if flag.get('all_account_details') is True and len(get_info['response']['reply']['checks']['accounts_status']['valid_accounts']) == 0:
             raise e.HealthStatusFailed(
                     f"Health command failed to get all account info with flag --all_account_details {flag.get('all_account_details')}"
                 )
-        if (flag.get('all_account_details') is False or flag.get('all_account_details') is None) and len(get_info['checks']['accounts_status']['valid_accounts']) != 0:
+        if (flag.get('all_account_details') is False) and ("accounts_status" in get_info['response']['reply']['checks'].keys()):
             raise e.HealthStatusFailed(
                     f"Health command failed to get all account info with flag --all_account_details {flag.get('all_account_details')}"
                 )
@@ -125,16 +113,10 @@ class Test_health_operations:
                         "all_bucket_details": False
                     },
             ),
-            pytest.param(
-                    {
-                        "all_bucket_details": None
-                    },
-            ),
         ],
         ids=[
              "true_value",
              "false_value",
-             "default_value",
         ],
     )
     def test_noobaa_bucket_flag(self, setup_prereqs, flag):
@@ -149,11 +131,11 @@ class Test_health_operations:
             raise e.HealthStatusFailed(
                     f"Health check failed for get all account with error {get_info['error']['error_code']}"
                 )
-        if flag.get('all_bucket_details') is True and len(get_info['checks']['buckets_status']['valid_buckets']) == 0:
+        if flag.get('all_bucket_details') is True and len(get_info['response']['reply']['checks']['buckets_status']['valid_buckets']) == 0:
             raise e.HealthStatusFailed(
                     f"Health command failed to get all account info with flag --all_bucket_details {flag.get('all_bucket_details')}"
                 )
-        if (flag.get('all_bucket_details') is False or flag.get('all_bucket_details') is None) and len(get_info['checks']['buckets_status']['valid_buckets']) != 0:
+        if (flag.get('all_bucket_details') is False) and ("buckets_status" in get_info['response']['reply']['checks'].keys()):
             raise e.HealthStatusFailed(
                     f"Health command failed to get all account info with flag --all_account_details {flag.get('all_bucket_details')}"
                 )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -41,25 +41,17 @@ def get_noobaa_health_status(
     log.info("Getting current Noobaa Health status")
     conn = SSHConnectionManager().connection
     cmd_options_data = kwargs
-    base_cmd = f"sudo /usr/local/noobaa-core/bin/node {HEALTH}"
+    base_cmd = f"sudo {HEALTH}"
     cmd_options = ""
     if "https_port" in cmd_options_data:
-        if cmd_options_data.get('https_port') is None:
-            cmd_options = cmd_options + "--https_port "
-        else:
-            cmd_options = cmd_options + f"--https_port {cmd_options_data.get('https_port')} "
+        assert cmd_options_data.get('https_port'), f"Default values are not supported for health check operation"
+        cmd_options = cmd_options + f"--https_port {cmd_options_data.get('https_port')} "
     if "deployment_type" in cmd_options_data:
         cmd_options = cmd_options + f"--deployment_type {cmd_options_data.get('deployment_type')} "
     if "all_account_details" in cmd_options_data:
-        if cmd_options_data.get('all_account_details') is None:
-            cmd_options = cmd_options + "--all_account_details "
-        else:
-            cmd_options = cmd_options + f"--all_account_details {cmd_options_data.get('all_account_details')} "
+        cmd_options = cmd_options + f"--all_account_details {cmd_options_data.get('all_account_details')} "
     if "all_bucket_details" in cmd_options_data:
-        if cmd_options_data.get('all_bucket_details') is None:
-            cmd_options = cmd_options + "--all_bucket_details "
-        else:
-            cmd_options = cmd_options + f"--all_bucket_details {cmd_options_data.get('all_bucket_details')} "
+        cmd_options = cmd_options + f"--all_bucket_details {cmd_options_data.get('all_bucket_details')} "
     cmd = f"{base_cmd} {cmd_options} --config_root {config_root} {constants.UNWANTED_LOG}"
     retcode, stdout, _ = conn.exec_cmd(cmd)
     if retcode != 0:


### PR DESCRIPTION
Removes support of testing health flag with default values due to below bug introduced in 4.17
https://bugzilla.redhat.com/show_bug.cgi?id=2262777

Below is the test result(Attached the snippet of test summary):
```
========================================================================= PASSES =========================================================================
_______________________________________________ Test_health_operations.test_noobaa_port_flag[custom_value] _______________________________________________
______________________________________________ Test_health_operations.test_noobaa_account_flag[true_value] _______________________________________________
______________________________________________ Test_health_operations.test_noobaa_account_flag[false_value] ______________________________________________
_______________________________________________ Test_health_operations.test_noobaa_bucket_flag[true_value] _______________________________________________
______________________________________________ Test_health_operations.test_noobaa_bucket_flag[false_value] _______________________________________________
================================================================ short test summary info =================================================================
PASSED tests/test_health_operations.py::Test_health_operations::test_noobaa_port_flag[custom_value]
PASSED tests/test_health_operations.py::Test_health_operations::test_noobaa_account_flag[true_value]
PASSED tests/test_health_operations.py::Test_health_operations::test_noobaa_account_flag[false_value]
PASSED tests/test_health_operations.py::Test_health_operations::test_noobaa_bucket_flag[true_value]
PASSED tests/test_health_operations.py::Test_health_operations::test_noobaa_bucket_flag[false_value]
============================================================= 5 passed in 107.85s (0:01:47) ==============================================================
```