### PR TITLE
Adds tests for validating multipart server side copy operation

### DIFF
--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -199,6 +199,11 @@ class NSFSAccount(Account):
         log.info(stdout)
         if retcode != 0:
             raise AccountListFailed(f"Listing of accounts failed with error {stdout}")
+        account_ls = json.loads(stdout)
+        account_ls = account_ls["response"]["reply"]
+        account_list = [item["name"] for item in account_ls]
+        log.info(account_list)
+        return account_list
 
     def delete(self, account_name=None, config_root=None):
         """

--- a/noobaa_sa/bucket.py
+++ b/noobaa_sa/bucket.py
@@ -28,7 +28,9 @@ class BucketManager:
         self.unwanted_log = "2>/dev/null"
         self.conn = SSHConnectionManager().connection
 
-    def create(self, account_name, bucket_name, config_root=None):
+    def create(
+        self, account_name, bucket_name, config_root=None, custom_bucket_path=None
+    ):
         """
         Create bucket using CLI
 
@@ -47,9 +49,14 @@ class BucketManager:
         log.info(stdout)
         account_info = json.loads(stdout)
         account_owner = account_info["response"]["reply"]["name"]
-        bucket_path = account_info["response"]["reply"]["nsfs_account_config"][
-            "new_buckets_path"
-        ]
+        if custom_bucket_path is not None:
+            bucket_path = custom_bucket_path
+            cmd = f"sudo mkdir {bucket_path}"
+            self.conn.exec_cmd(cmd)
+        else:
+            bucket_path = account_info["response"]["reply"]["nsfs_account_config"][
+                "new_buckets_path"
+            ]
         cmd = f"{self.base_cmd} bucket add --config_root {config_root} --name {bucket_name} --owner {account_owner} --path {bucket_path} {self.unwanted_log}"
         retcode, stdout, stderr = self.conn.exec_cmd(cmd)
         if retcode != 0:

--- a/noobaa_sa/s3_client.py
+++ b/noobaa_sa/s3_client.py
@@ -290,7 +290,7 @@ class S3Client:
         )
         return response_dict
 
-    def copy_object(self, src_bucket, src_key, dest_bucket, dest_key):
+    def copy_object(self, src_bucket, src_key, dest_bucket, dest_key, **kwargs):
         """
         Copy an object using boto3
 
@@ -310,7 +310,11 @@ class S3Client:
         )
         copy_source = {"Bucket": src_bucket, "Key": src_key}
         response_dict = self._exec_boto3_method(
-            "copy_object", Bucket=dest_bucket, CopySource=copy_source, Key=dest_key
+            "copy_object",
+            Bucket=dest_bucket,
+            CopySource=copy_source,
+            Key=dest_key,
+            **kwargs,
         )
         return response_dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,8 @@ def account_manager_implementation(request, account_json=None):
         Make sure to delete the anonymous account
         """
         try:
+            for acc in acc_manager_instance.list():
+                acc_manager_instance.delete(account_name=acc)
             acc_manager_instance.delete(account_name="anonymous")
         except AccountDeletionFailed as e:
             log.warning(f"Failed to delete anonymous account: {e}")

--- a/tests/test_multipart_operations.py
+++ b/tests/test_multipart_operations.py
@@ -1,8 +1,22 @@
 import logging
+import os
+import pytest
 
-from utility.bucket_utils import upload_incomplete_multipart_object
+from common_ci_utils.random_utils import (
+    generate_unique_resource_name,
+    generate_random_files,
+)
+from utility.utils import (
+    check_data_integrity,
+    get_noobaa_sa_host_home_path,
+    get_env_config_root_full_path,
+    split_file_data_for_multipart_upload,
+)
+from noobaa_sa import constants
+from framework import config
 from framework.customizations.marks import tier1
-from utility.utils import check_data_integrity
+from noobaa_sa.s3_client import S3Client
+from utility.bucket_utils import upload_incomplete_multipart_object
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +41,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         log.info("Trying to complete multipart operation for the object")
         mp_response = c_scope_s3client.complete_multipart_object_upload(
@@ -50,7 +66,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         log.info("Completing multipart operation for the object")
         mp_response = c_scope_s3client.complete_multipart_object_upload(
@@ -76,7 +94,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         log.info("Completing multipart operation for the object")
         mp_response = c_scope_s3client.complete_multipart_object_upload(
@@ -104,7 +124,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         log.info(f"Listing incomplete multipart uploads for the object {obj_name}")
         part_resp = c_scope_s3client.list_uploaded_parts(
@@ -134,7 +156,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         log.info(
             f"Listing incomplete multipart uploads for the bucket {resp['bucket_name']}"
@@ -169,7 +193,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         obj_name = resp["object_names"][0]
         c_scope_s3client.complete_multipart_object_upload(
             resp["bucket_name"],
@@ -216,7 +242,9 @@ class TestMultipartOperations:
 
         """
         log.info("Uploading multipart object")
-        resp = upload_incomplete_multipart_object(c_scope_s3client, tmp_directories_factory)
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
         log.info("Aborting Multipart operation")
         obj_name = resp["object_names"][0]
         abort_resp = c_scope_s3client.abort_multipart_upload(
@@ -228,3 +256,151 @@ class TestMultipartOperations:
         ), f"Failed to abort upload operation for {obj_name}"
         log.info(abort_resp)
         log.info("Multipart operation Aborted successfully")
+
+    @tier1
+    @pytest.mark.parametrize(
+        argnames="extra_header",
+        argvalues=[
+            pytest.param(
+                {"MetadataDirective": "REPLACE"},
+            ),
+            pytest.param(
+                {"ContentType": "image/jpeg"},
+            ),
+        ],
+        ids=[
+            "MetadataDirective",
+            "ContentType",
+        ],
+    )
+    def test_copy_non_nsfs_multipart_object(
+        self, c_scope_s3client, tmp_directories_factory, extra_header
+    ):
+        """
+        Test multipart copy object operation from one bucket to another using BOTO s3:
+        1. Create new bucket and write multipart objects in it
+        2. Create another bucket
+        3. Copy multipart objects to the newly created bucket by adding x-headers
+        4. Validate data from original directory and new bucket using md5sum check
+
+        """
+        log.info("Uploading multipart object")
+        resp = upload_incomplete_multipart_object(
+            c_scope_s3client, tmp_directories_factory
+        )
+        obj_name = resp["object_names"][0]
+        log.info("Completing multipart operation for the object")
+        mp_response = c_scope_s3client.complete_multipart_object_upload(
+            resp["bucket_name"],
+            obj_name,
+            resp[f"{obj_name}_upload_id"],
+            resp["all_part_info"],
+        )
+        log.info(mp_response)
+        log.info("Multipart operation is completed")
+        # create second bucket
+        log.info("Creating new bucket to initiate copy operation")
+        bucket_to_copy = c_scope_s3client.create_bucket()
+        cp_response = c_scope_s3client.copy_object(
+            resp["bucket_name"], obj_name, bucket_to_copy, obj_name, **extra_header
+        )
+        assert (
+            cp_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        ), "Failed to upload multipart object"
+        log.info(cp_response)
+        c_scope_s3client.download_bucket_contents(bucket_to_copy, resp["results_dir"])
+        assert check_data_integrity(resp["origin_dir"], resp["results_dir"])
+        log.info("Both uploaded and copied data are identical")
+
+    def test_copy_obj_to_another_bucket_with_different_fs_path(
+        self,
+        account_manager,
+        bucket_manager,
+        tmp_directories_factory,
+        set_nsfs_server_config_root,
+    ):
+        """
+        Test multipart copy object operation from one bucket to another which has different FS_path using BOTO s3:
+        1. Create new bucket and write multipart objects in it
+        2. Create another bucket with different FS_path
+        3. Copy multipart objects to the newly created bucket
+        4. Validate data from original directory and new bucket using md5sum check
+        """
+        # Create account
+        account_name, access_key, secret_key = account_manager.create()
+        # Create buckets with different FS path
+        first_bucket_name = generate_unique_resource_name(prefix="bucket")
+        second_bucket_name = generate_unique_resource_name(prefix="bucket")
+        bucket_manager.create(account_name, first_bucket_name)
+        hd = get_noobaa_sa_host_home_path()
+        custom_bucket_path = os.path.join(hd, f"fs_{account_name}_{second_bucket_name}")
+        bucket_manager.create(
+            account_name, second_bucket_name, custom_bucket_path=custom_bucket_path
+        )
+        # Create s3 client to perform s3api operation
+        set_nsfs_server_config_root(get_env_config_root_full_path())
+        nb_sa_host_address = config.ENV_DATA["noobaa_sa_host"]
+        s3_client = S3Client(
+            endpoint=f"https://{nb_sa_host_address}:{constants.DEFAULT_NSFS_PORT}",
+            access_key=access_key,
+            secret_key=secret_key,
+        )
+        resp_dir = {}
+        origin_dir, results_dir = tmp_directories_factory(
+            dirs_to_create=["origin", "result"]
+        )
+        # Write multipart objects to the bucket
+        object_names = generate_random_files(
+            origin_dir,
+            1,
+            min_size="20M",
+            max_size="30M",
+        )
+        # Upload multipart object
+        log.info("Initiate multipart upload process")
+        get_upload_id = s3_client.initiate_multipart_object_upload(
+            first_bucket_name,
+            object_names[0],
+        )
+        resp_dir[f"{object_names[0]}_upload_id"] = get_upload_id
+        all_part_info = []
+        file_name = origin_dir + "/" + object_names[0]
+        part_size = "10M"
+        log.info(f"Split data into {part_size} size")
+        part_data = split_file_data_for_multipart_upload(file_name, part_size)
+        log.info("Initiating part uploads for multipart object")
+        for pd in range(len(part_data)):
+            part_id = pd + 1
+            part_info = s3_client.initiate_upload_part(
+                first_bucket_name,
+                object_names[0],
+                part_id,
+                get_upload_id,
+                part_data[pd],
+            )
+            all_part_info.append({"PartNumber": part_id, "ETag": part_info["ETag"]})
+        resp_dir["all_part_info"] = all_part_info
+        log.info("Completing multipart operation for the object")
+        mp_response = s3_client.complete_multipart_object_upload(
+            first_bucket_name,
+            object_names[0],
+            resp_dir[f"{object_names[0]}_upload_id"],
+            resp_dir["all_part_info"],
+        )
+        log.info(mp_response)
+        log.info("Multipart object uploaded successfully")
+        log.info("Initiating object copy operation to new bucket")
+        cp_response = s3_client.copy_object(
+            first_bucket_name,
+            object_names[0],
+            second_bucket_name,
+            object_names[0],
+        )
+        assert (
+            cp_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        ), "Failed to upload multipart object"
+        log.info(cp_response)
+        log.info("Download copied object and check data integrity with original object")
+        s3_client.download_bucket_contents(second_bucket_name, results_dir)
+        assert check_data_integrity(origin_dir, results_dir)
+        log.info("Both uploaded and copied data are identical")


### PR DESCRIPTION
Adds tests for validating multipart server side copy operation
This PR covers below scenarios:

- underlying source bucket path is not equal to target bucket path
- the header 'x-amz-metadata-directive' is 'REPLACE'
- content-type of the copy source and the target is not equal
