### PR TITLE
Adds script for validating bucket versioning

### DIFF
--- a/noobaa_sa/s3_client.py
+++ b/noobaa_sa/s3_client.py
@@ -221,13 +221,14 @@ class S3Client:
         )
         return response_dict
 
-    def get_object(self, bucket_name, object_key):
+    def get_object(self, bucket_name, object_key, **kwargs):
         """
         Get the contents of an object in an S3 bucket using boto3
 
         Args:
             bucket_name (str): The name of the bucket
             object_key (str): The key of the object
+            **kwargs (dict): Dictionary with extra parameters
 
         Returns:
             A dictionary containing the object's metadata and contents.
@@ -241,11 +242,11 @@ class S3Client:
         """
         log.info(f"Getting object {object_key} from bucket {bucket_name} via boto3")
         response_dict = self._exec_boto3_method(
-            "get_object", Bucket=bucket_name, Key=object_key
+            "get_object", Bucket=bucket_name, Key=object_key, **kwargs
         )
         return response_dict
 
-    def delete_object(self, bucket_name, object_key):
+    def delete_object(self, bucket_name, object_key, **kwargs):
         """
         Delete an object from an S3 bucket using boto3
 
@@ -260,7 +261,7 @@ class S3Client:
         """
         log.info(f"Deleting object {object_key} from bucket {bucket_name} via boto3")
         response_dict = self._exec_boto3_method(
-            "delete_object", Bucket=bucket_name, Key=object_key
+            "delete_object", Bucket=bucket_name, Key=object_key, **kwargs
         )
         return response_dict
 
@@ -370,6 +371,52 @@ class S3Client:
             "delete_bucket_policy", Bucket=bucket_name
         )
         return response_dict
+    
+    def put_bucket_versioning(self, bucket_name, status="Enabled"):
+        """
+        Set versioning on bucket using boto3
+
+        Args:
+            Bucket_name (str): The name of the bucket
+            status (str): Versioning status
+        
+        Returns:
+            dict : PutBucketVersioning response
+        """
+        log.info(f"Enabling versioning status {status} on bucket {bucket_name} via boto3")
+        return self._exec_boto3_method(
+            "put_bucket_versioning", Bucket=bucket_name, VersioningConfiguration={"Status": status}
+        )
+    
+    def get_bucket_versioning(self, bucket_name):
+        """
+        Get versioning status of the bucket using boto3
+
+        Args:
+            Bucket_name (str): The name of the bucket
+        
+        Returns:
+            dict : GetBucketVersioning response
+        """
+        log.info(f"Getting versioning status of bucket {bucket_name} via boto3")
+        return self._exec_boto3_method(
+            "get_bucket_versioning", Bucket=bucket_name
+        )
+
+    def list_object_versions(self, bucket_name, **kwargs):
+        """
+        List all object versions present in bucket using boto3
+
+        Args:
+            Bucket_name (str): The name of the bucket
+        
+        Returns:
+            dict : list_object_versions response
+        """
+        log.info(f"List all object versions present in bucket {bucket_name} via boto3")
+        return self._exec_boto3_method(
+            "list_object_versions", Bucket=bucket_name, **kwargs
+        )
 
     def upload_directory(self, local_dir, bucket_name, prefix=""):
         """

--- a/tests/test_bucket_versioning.py
+++ b/tests/test_bucket_versioning.py
@@ -1,0 +1,345 @@
+import logging
+import random
+from framework.customizations.marks import tier1
+from utility.utils import list_all_versions_of_the_object
+
+log = logging.getLogger(__name__)
+
+
+class TestBucketVersioningOperations:
+    """
+    Test S3 Bucket versioning operations using NSFS
+    """
+
+    obj_name = "obj_1"
+    obj_data = "Original data"
+
+    def setup_versioned_bucket(self, c_scope_s3client):
+        """
+        Setup the versioned bucket
+
+        Args:
+            c_scope_s3client (Object):
+        Return:
+            string: Versioned Bucket name
+        """
+        # Create regular bucket
+        bucket = c_scope_s3client.create_bucket()
+
+        # enable bucket versioning
+        c_scope_s3client.put_bucket_versioning(bucket, status="Enabled")
+        log.info(f"Enabled bucket versioning on bucket {bucket}")
+
+        return bucket
+
+    @tier1
+    def test_enable_disable_bucket_versioning(self, c_scope_s3client):
+        """
+        Test S3 Bucket versioning status:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Verify versioning is enabled on bucket
+        4. Suspend versioning on bucket
+        5. Verify versioning is suspended on bucket
+
+        """
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # get bucket versioning status
+        log.info("get versioning status after enabling it")
+        response = c_scope_s3client.get_bucket_versioning(bucket)
+        assert response["Status"] == "Enabled", "Versioning is not enabled on bucket"
+
+        # Suspend bucket versioning
+        c_scope_s3client.put_bucket_versioning(bucket, status="Suspended")
+        log.info(f"Bucket versioning suspended on bucket {bucket}")
+
+        # get bucket versioning status
+        log.info("get versioning status after suspending it")
+        response = c_scope_s3client.get_bucket_versioning(bucket)
+        assert response["Status"] == "Suspended", "Versioning is not enabled on bucket"
+
+    @tier1
+    def test_get_object_version_id_from_versioned_bucket(self, c_scope_s3client):
+        """
+        Test version id of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload data in versioned bucket
+        4. Get object metadata from the bucket
+        5. Verify version id is assigned to object or not
+        """
+
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload data in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        response = c_scope_s3client.put_object(bucket, self.obj_name, self.obj_data)
+        code = response["Code"]
+        assert code == 200, f"put_object failed with response code {code}"
+
+        # Get object metadata from the bucket and verify version id is assigned to object or not
+        response = c_scope_s3client.get_object(bucket, self.obj_name)
+        assert response["VersionId"] is not None, "Version id is not assigned to object"
+        version_id = response["VersionId"]
+        log.info(f"Version id of object {self.obj_name} is {version_id}")
+
+    @tier1
+    def test_object_version_ids_from_versioned_bucket(self, c_scope_s3client):
+        """
+        Test version id of the versioned data of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload data in versioned bucket
+        4. Get first object metadata from the bucket
+        5. re-upload new data with same object key
+        6. Get new object metadata from the bucket
+        7. Verify that both version ids are different from metadata
+        """
+
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload data in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        response = c_scope_s3client.put_object(bucket, self.obj_name, self.obj_data)
+        assert (
+            response["Code"] == 200
+        ), f"put_object failed with response code {response['Code']}"
+        old_version_id = response["VersionId"]
+
+        # Upload new data with same object name in versioned bucket to populate different version id
+        log.info("Uploading new data with same object name in versioned bucket")
+        new_data = self.obj_data + " New data"
+        response = c_scope_s3client.put_object(bucket, self.obj_name, new_data)
+        assert (
+            response["Code"] == 200
+        ), f"put_object failed with response code {response['Code']}"
+        new_version_id = response["VersionId"]
+        # Verify that both version ids are different from metadata
+
+        assert old_version_id != new_version_id, "Both Version ids are same"
+        log.info(f"Old version id of object {self.obj_name} is {old_version_id}")
+        log.info(f"New version id of object {self.obj_name} is {new_version_id}")
+
+    @tier1
+    def test_list_version_ids_from_versioned_bucket(self, c_scope_s3client):
+        """
+        Test list version ids of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload 10 versions of data in versioned bucket
+        4. List all versions of the object
+        5. Verify version id count is matching with uploaded versions
+        """
+
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload 10 copies of data with same object_key in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        for i in range(10):
+            current_data = self.obj_data + " " + str(i)
+            response = c_scope_s3client.put_object(bucket, self.obj_name, current_data)
+            assert (
+                response["Code"] == 200
+            ), f"put_object failed with response code {response['Code']}"
+
+        # List all versions of the object
+        version_list = list_all_versions_of_the_object(
+            c_scope_s3client, bucket, self.obj_name
+        )
+        for v in version_list:
+            log.info(v)
+        assert (
+            len(version_list) == 10
+        ), f"Uploaded 10 copies and listed {len(version_list)} copies of data"
+        log.info("Uploaded copies and listed copies count is same")
+
+    @tier1
+    def test_get_specific_version_of_the_object(self, c_scope_s3client):
+        """
+        Test list version ids of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload 5 versions of data in versioned bucket
+        4. Get specific version of the object
+        5. Verify the content of the object with original data
+        """
+
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload 5 copies of data with same object_key in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        data_dic = {}
+        for i in range(5):
+            current_data = self.obj_data + " " + str(i)
+            response = c_scope_s3client.put_object(bucket, self.obj_name, current_data)
+            assert (
+                response["Code"] == 200
+            ), f"put_object failed with response code {response['Code']}"
+            data_dic.update({response["VersionId"]: current_data})
+
+        # Get specific version of the object
+        ver_id = random.choice(list(data_dic.keys()))
+        get_obj_data = (
+            c_scope_s3client.get_object(bucket, self.obj_name, VersionId=ver_id)["Body"]
+            .read()
+            .decode("utf-8")
+        )
+        log.info(get_obj_data)
+
+        # Verify the content of the object with original data
+        assert (
+            data_dic[ver_id] == get_obj_data
+        ), "Original data and downloaded data does not match"
+        log.info("Original data and downloaded data is identical")
+
+    @tier1
+    def test_delete_specific_version_of_the_object(self, c_scope_s3client):
+        """
+        Test list version ids of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload 2 versions of data in versioned bucket
+        4. Delete first version of the object
+        5. List all versions of the object
+        6. Verify list returns only one version id of the object
+        """
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload 2 copies of data with same object_key in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        for i in range(2):
+            current_data = self.obj_data + " " + str(i)
+            response = c_scope_s3client.put_object(bucket, self.obj_name, current_data)
+            assert (
+                response["Code"] == 200
+            ), f"put_object failed with response code {response['Code']}"
+
+        # List all versions of the object
+        version_list = list_all_versions_of_the_object(
+            c_scope_s3client, bucket, self.obj_name
+        )
+        for v in version_list:
+            log.info(v)
+
+        # delete first version of the object
+        del_resp = c_scope_s3client.delete_object(
+            bucket, self.obj_name, VersionId=version_list[0]
+        )
+        assert (
+            del_resp["Code"] == 204
+        ), f"delete_object resulted in an unexpected response: {del_resp}"
+
+        # List all versions of the object after delete operaion
+        version_list = list_all_versions_of_the_object(
+            c_scope_s3client, bucket, self.obj_name
+        )
+        for v in version_list:
+            log.info(v)
+        assert (
+            len(version_list) == 1
+        ), f"Deletion of versioned object with version id failed"
+        log.info("Successfully deleted versioned object with version id")
+
+    @tier1
+    def test_delete_restore_versioned_object(self, c_scope_s3client):
+        """
+        Test list version ids of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket
+        3. Upload object in versioned bucket
+        4. Delete object without specifying version of the object
+        5. Verify that the delete marker appears in version list
+        6. Restore object by deleting delete marker for the object
+        """
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Upload data with object_key in versioned bucket
+        log.info("Uploading data in versioned bucket")
+        response = c_scope_s3client.put_object(bucket, self.obj_name, self.obj_data)
+        assert (
+            response["Code"] == 200
+        ), f"put_object failed with response code {response['Code']}"
+
+        # delete the object
+        del_response = c_scope_s3client.delete_object(bucket, self.obj_name)
+        assert (
+            del_response["Code"] == 204
+        ), f"delete_object resulted in an unexpected response: {del_response}"
+
+        # Verify delete marker is added in version list of the object after delete operaion
+        response = c_scope_s3client.list_object_versions(bucket)
+        assert response["DeleteMarkers"][0]["VersionId"] == del_response.get(
+            "VersionId"
+        ), f"Delete marker is not added for object {self.obj_name}"
+        log.info("Delete marker added successfully to the deleted object")
+
+        # Restore object by deleting delete marker of the object
+        restore_resp = c_scope_s3client.delete_object(
+            bucket, self.obj_name, VersionId=del_response.get("VersionId")
+        )
+        assert (
+            restore_resp["Code"] == 204
+        ), f"delete_object resulted in an unexpected response: {del_response}"
+
+        response = c_scope_s3client.list_object_versions(bucket)
+        assert (
+            response["Versions"][0]["Key"] == self.obj_name
+            and response["Versions"][0]["IsLatest"] == True
+        ), f"Not able to restore object after deleting Delete marker for object {self.obj_name}"
+
+        restored_obj_data = (
+            c_scope_s3client.get_object(bucket, self.obj_name)["Body"]
+            .read()
+            .decode("utf-8")
+        )
+        log.info(restored_obj_data)
+
+        assert (
+            self.obj_data == restored_obj_data
+        ), "Original data and restored data does not match"
+        log.info("Object restored successfully after deleting Delete marker")
+
+    @tier1
+    def test_suspend_version_overwrite_object(self, c_scope_s3client):
+        """
+        Test list version ids of the object from versioned bucket:
+        1. Create regular bucket
+        2. Enable versioning on bucket and suspend it
+        3. Upload object in version suspended bucket
+        4. overwrite the object with same key
+        5. Verify that the only one version id is present for object
+        """
+        # Create regular bucket and enable versioning on it
+        bucket = self.setup_versioned_bucket(c_scope_s3client)
+
+        # Suspend bucket versioning on bucket
+        c_scope_s3client.put_bucket_versioning(bucket, status="Suspended")
+        log.info(f"Suspended bucket versioning on bucket {bucket}")
+
+        # Upload data two times with same object_key in bucket
+        log.info("Uploading data in suspended versioned bucket")
+        for i in range(2):
+            data = self.obj_data + " " + str(i)
+            response = c_scope_s3client.put_object(bucket, self.obj_name, data)
+            assert (
+                response["Code"] == 200
+            ), f"put_object failed with response code {response['Code']}"
+
+        # List all versions of the object
+        version_list = list_all_versions_of_the_object(
+            c_scope_s3client, bucket, self.obj_name
+        )
+        assert (
+            len(version_list) == 1 and version_list[0] == "null"
+        ), "Overwrite object operation is failed on suspended versioned bucket"
+        log.info(
+            "Successfully completed the overwrite object operation on suspended versioned bucket"
+        )

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -270,3 +270,23 @@ def get_noobaa_sa_rpm_name():
     except Exception as e:
         log.error(e)
         return ""
+
+
+def list_all_versions_of_the_object(s3client_obj, bucket_name, object_name):
+    """
+    returns list of version ids of the specific object
+
+    Args:
+        s3client_obj (obj): S3 client object
+        bucket_name  (str): versioned Bucket name
+        object_name  (str): Object name
+    Returns: list
+    """
+    version_id_list = []
+    log.info(f"Listing all versions available for object {object_name}")
+    response = s3client_obj.list_object_versions(bucket_name)
+    log.info(response)
+    for v in response["Versions"]:
+        if v["Key"] == object_name:
+            version_id_list.append(v["VersionId"])
+    return version_id_list


### PR DESCRIPTION
Adds script for validating bucket versioning
Pass log from jenkins:
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-noobaa-sa/273/

Passlog snippet:
```
========================================================================= PASSES =========================================================================
__________________________________________ TestBucketVersioningOperations.test_enable_disable_bucket_versioning __________________________________________
____________________________________ TestBucketVersioningOperations.test_get_object_version_id_from_versioned_bucket _____________________________________
______________________________________ TestBucketVersioningOperations.test_object_version_ids_from_versioned_bucket ______________________________________
_______________________________________ TestBucketVersioningOperations.test_list_version_ids_from_versioned_bucket _______________________________________
_________________________________________ TestBucketVersioningOperations.test_get_specific_version_of_the_object _________________________________________
_______________________________________ TestBucketVersioningOperations.test_delete_specific_version_of_the_object ________________________________________
______________________________________________ TestBucketVersioningOperations.test_delete_versioned_object _______________________________________________
__________________________________________ TestBucketVersioningOperations.test_restore_deleted_versioned_object __________________________________________
__________________________________________ TestBucketVersioningOperations.test_suspend_version_overwrite_object __________________________________________
================================================================ short test summary info =================================================================
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_enable_disable_bucket_versioning
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_get_object_version_id_from_versioned_bucket
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_object_version_ids_from_versioned_bucket
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_list_version_ids_from_versioned_bucket
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_get_specific_version_of_the_object
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_delete_specific_version_of_the_object
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_delete_versioned_object
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_restore_deleted_versioned_object
PASSED tests/test_bucket_versioning.py::TestBucketVersioningOperations::test_suspend_version_overwrite_object
======================================================= 9 passed, 70 warnings in 95.83s (0:01:35) ========================================================
(noobaa_sa_env) ➜  noobaa-sa-ci git:(bucket_versioning)
```