### PR TITLE
Adjust the `account_manager` fixture to only delete accounts and buckets that were created in its scope

### DIFF
--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -64,6 +64,10 @@ class NSFSAccount(Account):
     Account operations for NSFS Deployment type
     """
 
+    def __init__(self, account_json):
+        super().__init__(account_json)
+        self.accounts_created = []
+
     def create(
         self,
         account_name="",
@@ -146,6 +150,10 @@ class NSFSAccount(Account):
                 f"Creation of account failed with error {stdout}"
             )
         log.info("Account created successfully")
+
+        # Keep track of the accounts created
+        self.accounts_created.append(account_name)
+
         return account_name, access_key, secret_key
 
     def create_anonymous(self, uid=None, gid=None, user=None):
@@ -228,6 +236,11 @@ class NSFSAccount(Account):
         retcode, stdout, _ = self.conn.exec_cmd(cmd)
         if retcode != 0:
             raise AccountDeletionFailed(f"Deleting account failed with error {stdout}")
+        log.info("Account deleted successfully")
+
+        # Stop tracking the deleted account
+        if account_name in self.accounts_created:
+            self.accounts_created.remove(account_name)
 
     def update(self, account_name, update_params, config_root=None):
         """
@@ -260,6 +273,12 @@ class NSFSAccount(Account):
         retcode, stdout, _ = self.conn.exec_cmd(cmd)
         if retcode != 0:
             raise AccountUpdateFailed(f"Updating account failed with error {stdout}")
+        log.info("Account updated successfully")
+
+        # Update the account name for tracking if needed
+        if account_name in self.accounts_created and "new_name" in update_params.keys():
+            original_acc_ind = self.accounts_created.index(account_name)
+            self.accounts_created[original_acc_ind] = update_params["new_name"]
 
     def status(self, account_name, config_root=None):
         """

--- a/noobaa_sa/account.py
+++ b/noobaa_sa/account.py
@@ -191,6 +191,9 @@ class NSFSAccount(Account):
             )
         log.info("Anonymous account created successfully")
 
+        # Track for cleanup
+        self.accounts_created.append("anonymous")
+
     def list(self, config_root=None):
         """
         Lists accounts

--- a/noobaa_sa/bucket.py
+++ b/noobaa_sa/bucket.py
@@ -67,25 +67,30 @@ class BucketManager:
             raise e.BucketCreationFailed(f"Failed to create bucket {stderr}")
         log.info("Bucket created successfully")
 
-    def list(self, config_root=None):
+    def list(self, use_wide=False, config_root=None):
         """
         Lists Buckets
 
         Args:
+            use_wide (bool): Get more information about the buckets
             config_root (str): Path to config root
+
+        Returns:
+            list(str|dict): List of bucket names or dictionaries of bucket metadata if use_wide is True
         """
         if config_root is None:
             config_root = self.config_root
         log.info("Listing available buckets")
         cmd = f"{self.base_cmd} bucket list --config_root {config_root}"
+        cmd += " --wide" if use_wide else ""
         retcode, stdout, stderr = self.conn.exec_cmd(cmd)
         if retcode != 0:
             raise e.BucketListFailed(f"Listing of buckets failed with error {stderr}")
         bucket_ls = json.loads(stdout)
         bucket_ls = bucket_ls["response"]["reply"]
-        bucket_list = [item["name"] for item in bucket_ls]
-        log.info(bucket_list)
-        return bucket_list
+        bucket_ls = bucket_ls if use_wide else [item["name"] for item in bucket_ls]
+        log.info(bucket_ls)
+        return bucket_ls
 
     def delete(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,11 +58,16 @@ def account_manager_implementation(request, account_json=None):
         Make sure to delete the created account abd buckets
         """
         try:
+            # Delete all the accounts that were created by this fixture
             bucket_manager = BucketManager()
-            for bucket in bucket_manager.list():
-                bucket_manager.delete(bucket, force=True)
-            for acc in acc_manager_instance.list():
+            for acc in acc_manager_instance.accounts_created:
+                # Delete all the buckets that were created by this account
+                acc_id = acc_manager_instance.status(account_name=acc)["_id"]
+                for bucket in bucket_manager.list(use_wide=True):
+                    if bucket["owner_account"] == acc_id:
+                        bucket_manager.delete(bucket["name"], force=True)
                 acc_manager_instance.delete(account_name=acc)
+
             acc_manager_instance.delete(account_name="anonymous")
         except AccountDeletionFailed as e:
             log.warning(f"Failed to delete anonymous account: {e}")
@@ -388,4 +393,3 @@ def testsuite_properties(record_testsuite_property, pytestconfig):
         f"rp_launch_description",
         f"Job name:{noobaa_sa_rpm_name}\n{config.RUN.get('jenkins_build_url')}",
     )
-


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/noobaa-sa-ci/issues/48