### PR TITLE
Adjust the fs_backend flag in CLI bucket creation

### DIFF
--- a/noobaa_sa/bucket.py
+++ b/noobaa_sa/bucket.py
@@ -60,7 +60,7 @@ class BucketManager:
                 "new_buckets_path"
             ]
         if "custom_fs_backend" in kwargs:
-            extra_param = f"fs_backend = {kwargs.get('custom_fs_backend')} "
+            extra_param = f"--fs_backend={kwargs.get('custom_fs_backend')} "
         cmd = f"{self.base_cmd} bucket add --config_root {config_root} --name {bucket_name} --owner {account_owner} --path {bucket_path} {extra_param} {self.unwanted_log}"
         retcode, stdout, stderr = self.conn.exec_cmd(cmd)
         if retcode != 0:


### PR DESCRIPTION
Fix an automation issue that fails `test_copy_obj_to_another_bucket_with_different_fs_options[custom_fs_backend]`  with the following error:
```
    def create(self, account_name, bucket_name, config_root=None, **kwargs):
        """
        Create bucket using CLI
...
...
        if "custom_fs_backend" in kwargs:
            extra_param = f"fs_backend = {kwargs.get('custom_fs_backend')} "
        cmd = f"{self.base_cmd} bucket add --config_root {config_root} --name {bucket_name} --owner {account_owner} --path {bucket_path} {extra_param} {self.unwanted_log}"
        retcode, stdout, stderr = self.conn.exec_cmd(cmd)
        if retcode != 0:
>           raise e.BucketCreationFailed(f"Failed to create bucket {stderr}")
E           noobaa_sa.exceptions.BucketCreationFailed: Failed to create bucket
```

Before the adjustment, this is the CLI command that was passed, along with the response:
```
$ sudo /usr/local/noobaa-core/src/deploy/noobaa-cli bucket add --config_root ~/config_root --name bucket-e8ad581e --owner account-042a9d55 --path /home/jenkins/fs_account-042a9d55 fs_backend = NFSv4  2>/dev/null
{
  "error": {
    "code": "InvalidArgument",
    "message": "Invalid argument",
    "detail": "unexpected extra arguments detected: [\"fs_backend\",\"=\",\"NFSv4\"], ensure flag values are correctly formatted."
  }
}
```
It seems that the developers fixed the inconsistency regarding the `fs_backend` flag. Now we have to prefix it with `--` like any other flag:
```
sudo /usr/local/noobaa-core/src/deploy/noobaa-cli bucket add --config_root ~/config_root --name bucket-98796ac4 --owner account-6cc6719c --path /home/jenkins/fs_account-6cc6719c --fs_backend=NFSv4  2>/dev/null
{
  "response": {
    "code": "BucketCreated",
    "message": "Bucket has been created successfully: bucket-f1c8196b",
    "reply": {
      "_id": "680f51e210b5b9d454d34665",
      "name": "bucket-f1c8196b",
      "owner_account": "680f51841f6bf74c9c735796",
      "versioning": "DISABLED",
      "creation_date": "2025-04-28T10:01:05.996Z",
      "path": "/home/jenkins/fs_account-48f30554",
      "should_create_underlying_storage": false,
      "fs_backend": "NFSv4",
      "bucket_owner": "account-48f30554"
    }
  }
}
```